### PR TITLE
Replace Python usage of removed getargspec with getfullargspec

### DIFF
--- a/priv/python3/erlport/erlang.py
+++ b/priv/python3/erlport/erlang.py
@@ -25,7 +25,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from inspect import getargspec
+from inspect import getfullargspec
 import sys
 from sys import exc_info
 from traceback import extract_tb, format_list
@@ -127,8 +127,8 @@ class MessageHandler(object):
         self.handler = handler
 
     def _check_handler(self, handler):
-        # getargspec will raise TypeError if handler is not a function
-        args, varargs, _keywords, defaults = getargspec(handler)
+        # getfullargspec will raise TypeError if handler is not a function
+        args, varargs, _keywords, defaults = getfullargspec(handler)
         largs = len(args)
         too_much = largs > 1 and largs - len(default) > 1
         too_few = largs == 0 and varargs is None


### PR DESCRIPTION
getargspec is removed in Python 3.11 and was depreciated since Python 3

Signed-off-by: Thomas Citharel <tcit@tcit.fr>